### PR TITLE
Added ShaderExpo in - GLSL Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Processing Unit (GPU).
 * [Shader Toy](https://www.shadertoy.com) - Most popular live editor for fragment shaders.
 * [ShaderFrog](https://shaderfrog.com/) - WebGL Shader Editor and Composer.
 * [SHDR Editor](http://shdr.bkcore.com) - Live GLSL shader editor, viewer and validator.
-* [ShaderExpo](https://anuraghazra.github.io/ShaderExpo/) - Dependency free shader editor featuring inline error logs, auto completions, models and textures loading. made in Raw WebGL API.
+* [ShaderExpo](https://anuraghazra.github.io/ShaderExpo/) - Dependency free shader editor featuring inline error logs, auto completions, models and textures loading. 
 
 ### References
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Processing Unit (GPU).
 * [Shader Toy](https://www.shadertoy.com) - Most popular live editor for fragment shaders.
 * [ShaderFrog](https://shaderfrog.com/) - WebGL Shader Editor and Composer.
 * [SHDR Editor](http://shdr.bkcore.com) - Live GLSL shader editor, viewer and validator.
+* [ShaderExpo](https://anuraghazra.github.io/ShaderExpo/) - Dependency free shader editor featuring inline error logs, auto completions, models and textures loading. made in Raw WebGL API.
 
 ### References
 


### PR DESCRIPTION
ShaderExpo is purely dependency free shader editor made in Raw WebGL API. 

give it a try: https://anuraghazra.github.io/ShaderExpo

[read more](https://github.com/anuraghazra/ShaderExpo/blob/master/readme.md)

### Features
- Auto Completion
- Inline Errors
- Custom OBJ Model Loading
- Simple UI

source-code: https://github.com/anuraghazra/ShaderExpo